### PR TITLE
1. Attempt to read mzML file in local working directory if not found …

### DIFF
--- a/Deep_search/Deep_search/deep_structs.h
+++ b/Deep_search/Deep_search/deep_structs.h
@@ -13,6 +13,7 @@ typedef struct dsXIC {
 
 typedef struct dsPSM {
   std::string pep_seq;
+  std::string pep_seq_stripped;
   std::string prot_seq;
 	bool decoy;
   bool proteotypic = 0;
@@ -79,7 +80,8 @@ typedef struct parameters {
 
 	double probability;   //peptide prophet probability parameter 
 	std::string filename; //filename parameter
-	bool iprophet;        //identifieer for ipro or peptide prophet 
+	bool enzymeSense;     //n-term=true, c-term=false
+  bool iprophet;        //identifieer for ipro or peptide prophet 
 	std::string mzml;     //spectra file
 	float ret_time; 
 	double ppm; 

--- a/Deep_search/Deep_search/scan_reader.cpp
+++ b/Deep_search/Deep_search/scan_reader.cpp
@@ -10,7 +10,15 @@ bool scan_reader::mzml(peptide_lists& my_peptide_lists, my_parameters& my_params
 	BasicSpectrum mySpec;
   MzParser myfile(&mySpec);
 
-	if(!myfile.load(my_params.mzml.c_str())) return false;
+	if(!myfile.load(my_params.mzml.c_str())) {
+    string local= my_params.mzml;
+    size_t ret = local.find_last_of('\\');
+    if(ret==string::npos) local.find_last_of('/');
+    if(ret==string::npos) return false;
+    local=local.substr(ret+1,local.size());
+    cout << "WARNING: " << my_params.mzml << " not found. Attempting: " << local << endl;
+    if (!myfile.load(local.c_str())) return false;
+  }
 
 	//MH: We need to get through precursor peak extraction fast.
 	//To do so, we need to do it a) using a single pass through all arrays, and


### PR DESCRIPTION
…from the pepXML path (i.e. files were moved).

2. Added new parameter and feature to allow N-term enzyme cleavage
3. Automatically detect PeptideProphet and iProphet from the pepXML file. Removed command line parameter requiring user to identify this information.
4. Fixed bug with nonspecific designation at terminal peptides.
5. Set default anti-cut site to nothing. In other words, no need to put in nonsense character if disabling proline protection because proline is no longer the default.